### PR TITLE
Add security job to CI workflow for vulnerability checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   linter:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
@@ -29,6 +30,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
 
@@ -57,3 +59,16 @@ jobs:
 
       - name: Tear down the Stack
         run: docker compose -f docker-compose.local.yml down
+
+  # PyUp Safety CLI is a tool that checks Python dependencies for known security vulnerabilities.
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Run Safety CLI to check for vulnerabilities
+        uses: pyupio/safety-action@v1
+        with:
+          api-key: ${{ secrets.SAFETY_API_KEY }}


### PR DESCRIPTION
Add PyUp Safety to the CI workflow to check Python dependencies for known security vulnerabilities.