### PR TITLE
CI workflow: add coverage report upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ env:
 
 on:
   pull_request:
-    branches: ['master', 'main']
+    branches: ['main']
     paths-ignore: ['docs/**']
 
   push:
-    branches: ['master', 'main']
+    branches: ['main']
     paths-ignore: ['docs/**']
 
 concurrency:
@@ -34,7 +34,7 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
 
-  # With no caching at all the entire ci process takes 3m to complete!
+  # Run the tests using pytest and upload the coverage reports to Codecov
   pytest:
     runs-on: ubuntu-latest
 
@@ -55,10 +55,16 @@ jobs:
         run: docker compose -f docker-compose.local.yml run --rm django python manage.py migrate
 
       - name: Run Django Tests
-        run: docker compose -f docker-compose.local.yml run django pytest
+        run: docker compose -f docker-compose.local.yml run django pytest --cov --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Tear down the Stack
         run: docker compose -f docker-compose.local.yml down
+
 
   # PyUp Safety CLI is a tool that checks Python dependencies for known security vulnerabilities.
   security:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -22,13 +22,13 @@ sphinx-autobuild==2024.10.3 # https://github.com/GaretJax/sphinx-autobuild
 # ------------------------------------------------------------------------------
 ruff==0.8.4  # https://github.com/astral-sh/ruff
 coverage==7.6.10  # https://github.com/nedbat/coveragepy
+pytest-cov==6.0.0  # https://github.com/pytest-dev/pytest-cov
 djlint==1.36.4  # https://github.com/Riverside-Healthcare/djLint
 pre-commit==4.0.1  # https://github.com/pre-commit/pre-commit
 
 # Django
 # ------------------------------------------------------------------------------
 factory-boy==3.3.1  # https://github.com/FactoryBoy/factory_boy
-
 django-debug-toolbar==4.4.6  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==3.1.0  # https://github.com/nedbat/django_coverage_plugin


### PR DESCRIPTION
This commit adds the necessary steps to the CI workflow to run the tests using pytest and upload the coverage reports to Codecov.

It also adds the `pytest-cov` dependency to `requirements/local.txt`.